### PR TITLE
fix #3 イシュー番号に#issuecommentなどがついている場合にラベルの付け替えができない

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -5,7 +5,7 @@ chrome.runtime.onInstalled.addListener(function (details) {
 });
 
 this.issueUrlRegExp = new RegExp(
-        'https:\/\/github.com\/(.+)\/(.+)\/(issues|pull)\/(.+)');
+        'https:\/\/github.com\/(.+)\/(.+)\/(issues|pull)\/(\\d+)(.*)');
 
 this.stateLabels = [ 'doing', 'wait accepting', 'accepting', 'reopen', 'done' ];
 


### PR DESCRIPTION
- 数字以降もイシュー番号として扱われていたため、数字のみを切り出せるように変更した
